### PR TITLE
Make CloudWatch namespace configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Options:
                   environment variable.
                                [default: "http://admin:password@localhost:5984"]
   --scanDb, -s    Scan each database in addition to each node.  [default: false]
+  --namespace, -n  The CloudWatch Namespace to use
   --interval, -i  Interval between scanning for metrics in milliseconds.
                                                                 [default: 60000]
 ```

--- a/bin.js
+++ b/bin.js
@@ -26,6 +26,10 @@ require('yargs')
     description: 'Scan each database in addition to each node.',
     default: false
   })
+  .option('namespace', {
+    alias: 'n',
+    description: 'The CloudWatch Namespace to use'
+  })
   .command({
     command: '$0',
     aliases: ['start'],
@@ -37,8 +41,8 @@ require('yargs')
         default: 60000 // one minute
       })
     },
-    handler: function ({ url, interval, scanDb }) {
-      const watcher = new AWSCouchWatch({ url, scanDb })
+    handler: function ({ url, interval, scanDb, namespace }) {
+      const watcher = new AWSCouchWatch({ url, scanDb, namespace })
       watcher.setup().then(() => {
         setInterval(function () {
           return scanWith(watcher)
@@ -49,8 +53,8 @@ require('yargs')
   .command({
     command: 'scan',
     description: 'Scan a CouchDB instance once and upload the results to AWS CloudWatch.',
-    handler: function ({ url, scanDb }) {
-      const watcher = new AWSCouchWatch({ url, scanDb })
+    handler: function ({ url, scanDb, namespace }) {
+      const watcher = new AWSCouchWatch({ url, scanDb, namespace })
       watcher.setup().then(() => {
         scanWith(watcher)
       })

--- a/index.js
+++ b/index.js
@@ -3,14 +3,15 @@
 const AWS = require('aws-sdk')
 const CouchScan = require('./lib/scan')
 
-const Namespace = 'CouchWatch'
+const DEFAULT_NAMESPACE = 'CouchWatch'
 const MAX_SIZE = 20
 
 class AWSCouchWatch extends CouchScan {
-  constructor ({ url, aws, scanDb }) {
+  constructor ({ url, aws, scanDb, namespace }) {
     super({ url, scanDb })
     if (aws) AWS.config.update(aws)
     this.cloud = new AWS.CloudWatch()
+    this.namespace = namespace || DEFAULT_NAMESPACE
   }
 
   upload (metrics) {
@@ -31,7 +32,7 @@ class AWSCouchWatch extends CouchScan {
 
   _upload (metrics) {
     const params = {
-      Namespace,
+      Namespace: this.namespace,
       MetricData: metrics.map(({ key, value, type }) => {
         const MetricName = key
         const Value = value


### PR DESCRIPTION
In case people wanted to monitor different clusters / nodes on their own in the same AWS account, all metrics would currently end up in the same CloudWatch namespace.

This PR adds an option to override the default value.